### PR TITLE
geom_alt props

### DIFF
--- a/data/421/168/855/421168855.geojson
+++ b/data/421/168/855/421168855.geojson
@@ -624,6 +624,9 @@
     ],
     "wof:country":"UZ",
     "wof:created":1459008783,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08f064e0cb5e9b511ba78dff08ba22b4",
     "wof:hierarchy":[
         {
@@ -634,7 +637,7 @@
         }
     ],
     "wof:id":421168855,
-    "wof:lastmodified":1566643822,
+    "wof:lastmodified":1582379076,
     "wof:name":"Tashkent",
     "wof:parent_id":85680429,
     "wof:placetype":"locality",

--- a/data/856/326/45/85632645.geojson
+++ b/data/856/326/45/85632645.geojson
@@ -986,7 +986,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1059,7 +1058,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1582379069,
+    "wof:lastmodified":1583259822,
     "wof:name":"Uzbekistan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/326/45/85632645.geojson
+++ b/data/856/326/45/85632645.geojson
@@ -986,6 +986,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1040,6 +1041,10 @@
     },
     "wof:country":"UZ",
     "wof:country_alpha3":"UZB",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"42b30b065ed38867009fa7731e085068",
     "wof:hierarchy":[
         {
@@ -1054,7 +1059,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1566643360,
+    "wof:lastmodified":1582379069,
     "wof:name":"Uzbekistan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/859/037/73/85903773.geojson
+++ b/data/859/037/73/85903773.geojson
@@ -75,6 +75,9 @@
         "gp:id":2269282
     },
     "wof:country":"UZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66e81f1f9ab854339171325772439198",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566643357,
+    "wof:lastmodified":1582379067,
     "wof:name":"Aktepa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/75/85903775.geojson
+++ b/data/859/037/75/85903775.geojson
@@ -69,6 +69,9 @@
         "gp:id":2271575
     },
     "wof:country":"UZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"433c6156e9276408813a6ee362044df8",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566643357,
+    "wof:lastmodified":1582379068,
     "wof:name":"Qoraqamish",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/435/301/890435301.geojson
+++ b/data/890/435/301/890435301.geojson
@@ -321,6 +321,9 @@
     },
     "wof:country":"UZ",
     "wof:created":1469052062,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"75a4692fbbb01d01716acdef6e2b2efb",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
         }
     ],
     "wof:id":890435301,
-    "wof:lastmodified":1566643837,
+    "wof:lastmodified":1582379077,
     "wof:name":"Urganch",
     "wof:parent_id":85680377,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.