### PR TITLE
uz concordances, placetype local, and more

### DIFF
--- a/data/856/326/45/85632645.geojson
+++ b/data/856/326/45/85632645.geojson
@@ -1241,6 +1241,7 @@
         "hasc:id":"UZ",
         "icao:code":"UK",
         "ioc:id":"UZB",
+        "iso:code":"UZ",
         "itu:id":"UZB",
         "loc:id":"n91129869",
         "m49:code":"860",
@@ -1254,6 +1255,7 @@
         "wk:page":"Uzbekistan",
         "wmo:id":"UZ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UZ",
     "wof:country_alpha3":"UZB",
     "wof:geom_alt":[
@@ -1274,7 +1276,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1694639561,
+    "wof:lastmodified":1695881219,
     "wof:name":"Uzbekistan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/803/73/85680373.geojson
+++ b/data/856/803/73/85680373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.248123,
-    "geom:area_square_m":40132536684.175072,
+    "geom:area_square_m":40132541039.463638,
     "geom:bbox":"62.18037,38.940374,65.365447,41.493282",
     "geom:latitude":40.178214,
     "geom:longitude":63.719414,
@@ -379,13 +379,15 @@
         "gn:id":1114929,
         "gp:id":2347660,
         "hasc:id":"UZ.BU",
+        "iso:code":"UZ-BU",
         "iso:id":"UZ-BU",
         "qs_pg:id":1135448,
         "unlc:id":"UZ-BU",
         "wd:id":"Q487372"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UZ",
-    "wof:geomhash":"3660bef9bee4488c4b90e6bdf5a98080",
+    "wof:geomhash":"e0f97a663c281d15bca89e6467ff1282",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -400,7 +402,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1690893349,
+    "wof:lastmodified":1695884955,
     "wof:name":"Bukhoro",
     "wof:parent_id":85632645,
     "wof:placetype":"region",

--- a/data/856/803/77/85680377.geojson
+++ b/data/856/803/77/85680377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.763579,
-    "geom:area_square_m":7088350967.449285,
+    "geom:area_square_m":7088347791.00181,
     "geom:bbox":"60.049182,40.505516,62.447279,42.005576",
     "geom:latitude":41.344159,
     "geom:longitude":61.023834,
@@ -355,14 +355,16 @@
         "gn:id":1484843,
         "gp:id":2347665,
         "hasc:id":"UZ.KH",
+        "iso:code":"UZ-XO",
         "iso:id":"UZ-XO",
         "qs_pg:id":555924,
         "unlc:id":"UZ-KH",
         "wd:id":"Q487561",
         "wk:page":"Xorazm Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UZ",
-    "wof:geomhash":"95a0f6a05decea21fa01cce326a69223",
+    "wof:geomhash":"436301edaab570cf44dce3fc25569de7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -377,7 +379,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1690893349,
+    "wof:lastmodified":1695884956,
     "wof:name":"Khorezm",
     "wof:parent_id":85632645,
     "wof:placetype":"region",

--- a/data/856/803/81/85680381.geojson
+++ b/data/856/803/81/85680381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":18.375296,
-    "geom:area_square_m":165003440497.364899,
+    "geom:area_square_m":165003441936.788177,
     "geom:bbox":"55.975839,40.985871,62.470999,45.558719",
     "geom:latitude":43.421428,
     "geom:longitude":58.818394,
@@ -444,12 +444,14 @@
         "gn:id":453752,
         "gp:id":2347663,
         "hasc:id":"UZ.QR",
+        "iso:code":"UZ-QR",
         "iso:id":"UZ-QR",
         "qs_pg:id":1135451,
         "wd:id":"Q484245"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UZ",
-    "wof:geomhash":"f00ccbdc75806272a5e808ad69d4d9da",
+    "wof:geomhash":"78052d57e37069ecab234e8188d3ae8e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -464,7 +466,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1690893349,
+    "wof:lastmodified":1695884546,
     "wof:name":"Karakalpakstan",
     "wof:parent_id":85632645,
     "wof:placetype":"region",

--- a/data/856/803/85/85680385.geojson
+++ b/data/856/803/85/85680385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":11.957017,
-    "geom:area_square_m":109902964391.175766,
+    "geom:area_square_m":109902959875.347183,
     "geom:bbox":"61.743084,39.464258,66.801225,43.722785",
     "geom:latitude":41.975654,
     "geom:longitude":64.359571,
@@ -353,13 +353,15 @@
         "gn:id":1484841,
         "gp:id":2347667,
         "hasc:id":"UZ.NW",
+        "iso:code":"UZ-NW",
         "iso:id":"UZ-NW",
         "qs_pg:id":1135453,
         "unlc:id":"UZ-NW",
         "wd:id":"Q487570"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UZ",
-    "wof:geomhash":"01e5376e38c14d89b7588becc2527a99",
+    "wof:geomhash":"39686aca1fd5bb4328718d3340cfcc70",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -374,7 +376,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1690893350,
+    "wof:lastmodified":1695884956,
     "wof:name":"Navoi",
     "wof:parent_id":85632645,
     "wof:placetype":"region",

--- a/data/856/803/89/85680389.geojson
+++ b/data/856/803/89/85680389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.737418,
-    "geom:area_square_m":16496633480.856766,
+    "geom:area_square_m":16496632678.224735,
     "geom:bbox":"65.121483,39.290431,67.503715,40.626616",
     "geom:latitude":39.835725,
     "geom:longitude":66.398903,
@@ -343,14 +343,16 @@
         "gn:id":1114927,
         "gp:id":20070173,
         "hasc:id":"UZ.SA",
+        "iso:code":"UZ-SA",
         "iso:id":"UZ-SA",
         "qs_pg:id":1085808,
         "unlc:id":"UZ-SA",
         "wd:id":"Q487532",
         "wk:page":"Samarqand Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UZ",
-    "wof:geomhash":"9e220940fb2a0096206d44aa52cec8df",
+    "wof:geomhash":"c2de495482a760f6a1bd2bf9660dcc24",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -365,7 +367,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1690893348,
+    "wof:lastmodified":1695884956,
     "wof:name":"Samarkand",
     "wof:parent_id":85632645,
     "wof:placetype":"region",

--- a/data/856/803/95/85680395.geojson
+++ b/data/856/803/95/85680395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.025187,
-    "geom:area_square_m":29135011876.943752,
+    "geom:area_square_m":29135006882.996735,
     "geom:bbox":"64.367566,37.966593,67.678587,39.556759",
     "geom:latitude":38.842265,
     "geom:longitude":66.09501,
@@ -352,14 +352,16 @@
         "gn:id":1114928,
         "gp:id":2347664,
         "hasc:id":"UZ.QA",
+        "iso:code":"UZ-QA",
         "iso:id":"UZ-QA",
         "qs_pg:id":219629,
         "unlc:id":"UZ-QA",
         "wd:id":"Q487577",
         "wk:page":"Qashqadaryo Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UZ",
-    "wof:geomhash":"6ce133e359d5560c4284bbe3bea5c8a1",
+    "wof:geomhash":"33e955e63a9c28f1804c23556d3c8b49",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -374,7 +376,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1690893348,
+    "wof:lastmodified":1695884956,
     "wof:name":"Kashkadarya",
     "wof:parent_id":85632645,
     "wof:placetype":"region",

--- a/data/856/803/97/85680397.geojson
+++ b/data/856/803/97/85680397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.992195,
-    "geom:area_square_m":19405728188.395035,
+    "geom:area_square_m":19405730549.459923,
     "geom:bbox":"66.493491,37.185147,68.360664,39.002978",
     "geom:latitude":38.020592,
     "geom:longitude":67.458519,
@@ -348,13 +348,15 @@
         "gn:id":1114926,
         "gp:id":2347668,
         "hasc:id":"UZ.SU",
+        "iso:code":"UZ-SU",
         "iso:id":"UZ-SU",
         "qs_pg:id":1135452,
         "unlc:id":"UZ-SU",
         "wd:id":"Q487537"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UZ",
-    "wof:geomhash":"011d7c77381a62dd24943a6e58539548",
+    "wof:geomhash":"dd8a399eca576eb7a4c4b16b926cd145",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -369,7 +371,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1690893349,
+    "wof:lastmodified":1695884956,
     "wof:name":"Surkhandarya",
     "wof:parent_id":85632645,
     "wof:placetype":"region",

--- a/data/856/804/01/85680401.geojson
+++ b/data/856/804/01/85680401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.459518,
-    "geom:area_square_m":4304277712.248594,
+    "geom:area_square_m":4304277463.758305,
     "geom:bbox":"71.581812,40.38565,73.148641,41.072843",
     "geom:latitude":40.753451,
     "geom:longitude":72.320385,
@@ -369,14 +369,16 @@
         "gn:id":1484846,
         "gp:id":2347659,
         "hasc:id":"UZ.AN",
+        "iso:code":"UZ-AN",
         "iso:id":"UZ-AN",
         "qs_pg:id":895013,
         "unlc:id":"UZ-AN",
         "wd:id":"Q487384",
         "wk:page":"Andijan Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UZ",
-    "wof:geomhash":"edcd6a90bf9c7946cce583bc6b075e8c",
+    "wof:geomhash":"f3af160152beb81bf1a5e962ca4016fc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -391,7 +393,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1690893347,
+    "wof:lastmodified":1695884955,
     "wof:name":"Andijon",
     "wof:parent_id":85632645,
     "wof:placetype":"region",

--- a/data/856/804/07/85680407.geojson
+++ b/data/856/804/07/85680407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.773367,
-    "geom:area_square_m":7278420840.360947,
+    "geom:area_square_m":7278420695.474513,
     "geom:bbox":"70.353824,39.874466,72.228328,40.774747",
     "geom:latitude":40.437051,
     "geom:longitude":71.279152,
@@ -364,12 +364,14 @@
         "gn:id":1484845,
         "gp:id":2347662,
         "hasc:id":"UZ.FA",
+        "iso:code":"UZ-FA",
         "iso:id":"UZ-FA",
         "qs_pg:id":1135450,
         "wd:id":"Q487089"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UZ",
-    "wof:geomhash":"e7586ce6d372e40db914fb4e85f96cbf",
+    "wof:geomhash":"39f9cedb56de39e6611ce4e564f36fe9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -384,7 +386,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1690893347,
+    "wof:lastmodified":1695884955,
     "wof:name":"Ferghana",
     "wof:parent_id":85632645,
     "wof:placetype":"region",

--- a/data/856/804/11/85680411.geojson
+++ b/data/856/804/11/85680411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.81817,
-    "geom:area_square_m":7629540309.549608,
+    "geom:area_square_m":7629543036.476124,
     "geom:bbox":"70.397181,40.616901,72.195486,41.54992",
     "geom:latitude":41.049358,
     "geom:longitude":71.2518,
@@ -353,14 +353,16 @@
         "gn:id":1484842,
         "gp:id":2347666,
         "hasc:id":"UZ.NG",
+        "iso:code":"UZ-NG",
         "iso:id":"UZ-NG",
         "qs_pg:id":959522,
         "unlc:id":"UZ-NG",
         "wd:id":"Q474876",
         "wk:page":"Namangan Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UZ",
-    "wof:geomhash":"ba07f374f2ef1e3f0d0b4a29e00a63b5",
+    "wof:geomhash":"2da63e24316b0165fdd9b3901b0ee479",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -375,7 +377,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1690893346,
+    "wof:lastmodified":1695884955,
     "wof:name":"Namangan",
     "wof:parent_id":85632645,
     "wof:placetype":"region",

--- a/data/856/804/15/85680415.geojson
+++ b/data/856/804/15/85680415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.213482,
-    "geom:area_square_m":20850750610.451153,
+    "geom:area_square_m":20850749311.844357,
     "geom:bbox":"66.61426,39.484413,68.696545,41.20038",
     "geom:latitude":40.374117,
     "geom:longitude":67.641471,
@@ -358,12 +358,14 @@
         "gn:id":1484844,
         "gp:id":2347661,
         "hasc:id":"UZ.JI",
+        "iso:code":"UZ-JI",
         "iso:id":"UZ-JI",
         "qs_pg:id":1135449,
         "wd:id":"Q488811"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UZ",
-    "wof:geomhash":"a492e9b591d74996f79718a6fcca0bb5",
+    "wof:geomhash":"6a2b0e80c22431600699ed43f8ba4da0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -378,7 +380,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1690893347,
+    "wof:lastmodified":1695884956,
     "wof:name":"Jizzakh",
     "wof:parent_id":85632645,
     "wof:placetype":"region",

--- a/data/856/804/19/85680419.geojson
+++ b/data/856/804/19/85680419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.513254,
-    "geom:area_square_m":4830623508.651359,
+    "geom:area_square_m":4830622752.978193,
     "geom:bbox":"68.091792,39.819638,69.124029,40.951691",
     "geom:latitude":40.432992,
     "geom:longitude":68.6621,
@@ -347,14 +347,16 @@
         "gn:id":1484840,
         "gp:id":2347669,
         "hasc:id":"UZ.SI",
+        "iso:code":"UZ-SI",
         "iso:id":"UZ-SI",
         "qs_pg:id":895020,
         "unlc:id":"UZ-SI",
         "wd:id":"Q487547",
         "wk:page":"Sirdaryo Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UZ",
-    "wof:geomhash":"c05652083b4ab4e35689b0cfce7e1a46",
+    "wof:geomhash":"4bc0844c632698f2b31ab1b9fc1504aa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -369,7 +371,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1690893347,
+    "wof:lastmodified":1695884955,
     "wof:name":"Sirdaryo",
     "wof:parent_id":85632645,
     "wof:placetype":"region",

--- a/data/856/804/25/85680425.geojson
+++ b/data/856/804/25/85680425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.60388,
-    "geom:area_square_m":14910024849.098688,
+    "geom:area_square_m":14910022790.024385,
     "geom:bbox":"68.649524,40.181735,71.253201,42.29096",
     "geom:latitude":41.251225,
     "geom:longitude":69.790107,
@@ -370,13 +370,15 @@
         "gn:id":1484839,
         "gp:id":2347670,
         "hasc:id":"UZ.TA",
+        "iso:code":"UZ-TO",
         "iso:id":"UZ-TO",
         "qs_pg:id":319271,
         "wd:id":"Q487585",
         "wk:page":"Tashkent"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UZ",
-    "wof:geomhash":"9f3b9e9bccbf3a210cf81c9beec2c993",
+    "wof:geomhash":"9dadcdb2c37d3131b737d067f9ce29ed",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -391,7 +393,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1690893348,
+    "wof:lastmodified":1695884327,
     "wof:name":"Tashkent",
     "wof:parent_id":85632645,
     "wof:placetype":"region",

--- a/data/856/804/29/85680429.geojson
+++ b/data/856/804/29/85680429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026099,
-    "geom:area_square_m":242377731.507044,
+    "geom:area_square_m":242378001.496943,
     "geom:bbox":"69.136069,41.219172,69.36377,41.403552",
     "geom:latitude":41.317804,
     "geom:longitude":69.249157,
@@ -362,17 +362,19 @@
         "gn:id":1484839,
         "gp:id":20070172,
         "hasc:id":"UZ.TK",
+        "iso:code":"UZ-TK",
         "iso:id":"UZ-TK",
         "loc:id":"n80004387",
         "qs_pg:id":236298,
         "wd:id":"Q487585",
         "wk:page":"Tashkent"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421168855
     ],
     "wof:country":"UZ",
-    "wof:geomhash":"1da93eecff968ab3a75626ba9747b797",
+    "wof:geomhash":"0483326d9a21d0e69b4ff4574b4182f7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -387,7 +389,7 @@
     "wof:lang_x_spoken":[
         "uzb"
     ],
-    "wof:lastmodified":1690893346,
+    "wof:lastmodified":1695884327,
     "wof:name":"Tashkent",
     "wof:parent_id":85632645,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.