### PR TITLE
Deduplicate records

### DIFF
--- a/data/120/953/772/7/1209537727.geojson
+++ b/data/120/953/772/7/1209537727.geojson
@@ -32,6 +32,13 @@
     "name:eng_x_preferred":[
         "Qo\u2018rg\u2018oncha"
     ],
+    "name:und_x_variant":[
+        "Kurganchi",
+        "Kurgancha"
+    ],
+    "name:uzb_x_preferred":[
+        "Qo\u2018rg\u2018oncha"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         85632645
@@ -39,6 +46,11 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7528102
+    },
+    "wof:concordances_alt":{
+        "gn:id":[
+            1513366
+        ]
     },
     "wof:country":"UZ",
     "wof:geomhash":"ecb9d14c3b337d7696a8047ea8171ae9",
@@ -49,13 +61,15 @@
         }
     ],
     "wof:id":1209537727,
-    "wof:lastmodified":1566643553,
+    "wof:lastmodified":1706241110,
     "wof:name":"Qo`rg`oncha",
     "wof:parent_id":85632645,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-uz",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1326844425
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/132/684/442/5/1326844425.geojson
+++ b/data/132/684/442/5/1326844425.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2024-01-19",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2024-01-19",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"71.77659,40.89075,71.77659,40.89075",
@@ -27,7 +29,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:und_x_variant":[
         "Kurganchi",
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1326844425,
-    "wof:lastmodified":1566643233,
+    "wof:lastmodified":1706241110,
     "wof:name":"Qo`rg`oncha",
     "wof:parent_id":85680401,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-uz",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1209537727
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2181. This PR deduplicates admin records across WOF.